### PR TITLE
If a player is expected in a match, he can't be a referee or spectator.

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
@@ -1061,7 +1061,7 @@ public class AutoRefMatch implements Metadatable
 	 */
 	public boolean isReferee(Player player)
 	{
-		if (isPlayer(player)) return false;
+		if (isPlayer(player) || getExpectedPlayers().contains(player)) return false;
 		return player.hasPermission("autoreferee.referee");
 	}
 
@@ -1072,7 +1072,7 @@ public class AutoRefMatch implements Metadatable
 	 */
 	public boolean isStreamer(Player player)
 	{
-		if (isPlayer(player)) return false;
+		if (isPlayer(player) || getExpectedPlayers().contains(player)) return false;
 		return isSpectator(player) && getSpectator(player).isStreamer();
 	}
 


### PR DESCRIPTION
isReferee() and isStreamer() only check to see if a player is a real player, a contestant, it should check for expected players too as CotM Refs can be expected to play and shouldn't have referee permissions in such occasions. I believe this change should fix that.
