### PR TITLE
For nightvision, send toggle message to the client instead of 0 vs 1 messages

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefSpectator.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefSpectator.java
@@ -57,7 +57,7 @@ public class AutoRefSpectator extends AutoRefPlayer
 	{
 		this.nightVision = b;
 		if (this.hasClientMod()) AutoRefMatch.messageReferee(getPlayer(),
-			"match", getMatch().getWorld().getName(), "nightvis", this.nightVision ? "1" : "0");
+			"match", getMatch().getWorld().getName(), "nightvis");
 		else this.applyNightVision();
 	}
 


### PR DESCRIPTION
This makes sure that /ar nightvis toggles the state of the nightvision. In particular because the client currently defaults to nightVision for good viewing of RFW maps.
