### PR TITLE
Improve teleportatoin caused by AutoReferee-client messages

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefSpectator.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefSpectator.java
@@ -17,6 +17,8 @@ public class AutoRefSpectator extends AutoRefPlayer
 	private boolean viewInventory = true;
 	private boolean invisible = true;
 	private boolean streamer;
+	
+	private Location prevLocation = null;
 
 	public AutoRefSpectator(String name, AutoRefMatch match)
 	{
@@ -107,4 +109,10 @@ public class AutoRefSpectator extends AutoRefPlayer
 
 	public void setViewInventory(boolean vi)
 	{ this.viewInventory = vi; }
+	
+	public Location prevLocation()
+	{ return prevLocation;}
+	
+	public void setPrevLocation(Location l)
+	{ this.prevLocation = l;}
 }

--- a/src/main/java/org/mctourney/autoreferee/commands/SpectatorCommands.java
+++ b/src/main/java/org/mctourney/autoreferee/commands/SpectatorCommands.java
@@ -30,13 +30,9 @@ public class SpectatorCommands implements CommandHandler
 {
 	AutoReferee plugin;
 
-	// save previous location before teleport
-	private Map<String, Location> prevLocation;
-
 	public SpectatorCommands(Plugin plugin)
 	{
 		this.plugin = (AutoReferee) plugin;
-		prevLocation = Maps.newHashMap();
 	}
 
 	@AutoRefCommand(name={"announce"},
@@ -176,8 +172,7 @@ public class SpectatorCommands implements CommandHandler
 		}
 		else if (options.hasOption('r'))
 		{
-			// get location in lookup table, or null
-			tplocation = prevLocation.get(player.getName());
+			tplocation = plugin.getMatch(player.getWorld()).getSpectator(player).prevLocation();
 		}
 		else if (args.length > 0)
 		{
@@ -191,7 +186,7 @@ public class SpectatorCommands implements CommandHandler
 		// if we ever found a valid teleport, take it!
 		if (tplocation != null && tplocation.getWorld() == player.getWorld())
 		{
-			prevLocation.put(player.getName(), player.getLocation());
+			plugin.getMatch(player.getWorld()).getSpectator(player).setPrevLocation(player.getLocation());
 			player.setFlying(true); player.teleport(tplocation);
 		}
 		else player.sendMessage(ChatColor.DARK_GRAY + "You cannot teleport to this location: invalid or unsafe. " + ChatColor.GRAY + targetcoords);

--- a/src/main/java/org/mctourney/autoreferee/listeners/SpectatorListener.java
+++ b/src/main/java/org/mctourney/autoreferee/listeners/SpectatorListener.java
@@ -136,6 +136,7 @@ public class SpectatorListener implements PluginMessageListener, Listener
 					"You cannot teleport to this location: invalid or unsafe.");
 				else 
 				{
+					plugin.getMatch(player.getWorld()).getSpectator(player).setPrevLocation(player.getLocation());
 					player.teleport(TeleportationUtil.locationTeleport(loc));
 					player.setFlying(true);
 				}


### PR DESCRIPTION
Improve the teleportation in two ways:

Set the player to flying mode
Saves the current location as prevLocation (refactors prevLocation to field in AutoRefSpectator).
