### PR TITLE
Update filepath of borrowed file in generate-colors.py

### DIFF
--- a/generate-colors.py
+++ b/generate-colors.py
@@ -2,7 +2,7 @@ import urllib.request
 import re
 
 # these colors are borrowed from webbukkit/DynmapCore
-COLOR_FILE = 'http://raw.github.com/webbukkit/DynmapCore/master/colorschemes/default.txt'
+COLOR_FILE = 'https://raw.github.com/webbukkit/DynmapCore/master/src/main/resources/extracted/colorschemes/default.txt'
 
 def check(line):
 	parts = line.split()


### PR DESCRIPTION
### Problem

It appears that Dynmap-Core has both mavenized and changed the structure of where they place the `colorschemes` files. As a result, the URL used in the script now is a 404.
### Breakdown

This commit changes the URL to the new correct one.
