### PR TITLE
Add workaround for start mechanisms when not SportBukkit

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
@@ -48,6 +48,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -61,6 +62,7 @@ import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.material.Attachable;
 import org.bukkit.material.Button;
 import org.bukkit.material.Lever;
 import org.bukkit.material.MaterialData;
@@ -2283,8 +2285,8 @@ public class AutoRefMatch implements Metadatable
 		// remove all mobs, animals, and items (again)
 		this.clearEntities();
 
-		// loop through all the redstone mechanisms required to start / FIXME BUKKIT-1858
-		if (SportBukkitUtil.hasSportBukkitApi()) for (StartMechanism sm : startMechanisms)
+		// loop through all the redstone mechanisms required to start
+		for (StartMechanism sm : startMechanisms)
 		{
 			MaterialData mdata = sm.getBlockState().getData();
 			switch (sm.getBlockState().getType())
@@ -2312,6 +2314,24 @@ public class AutoRefMatch implements Metadatable
 			// save the block state and fire an update
 			sm.getBlockState().setData(mdata);
 			sm.getBlockState().update(true);
+
+			// FIXME BUKKIT-1858
+			if (!SportBukkitUtil.hasSportBukkitApi()) {
+				// Determine attached block
+				BlockFace face = BlockFace.SELF;
+				if (mdata instanceof Attachable) {
+					face = ((Attachable) mdata).getAttachedFace();
+				} else if (mdata instanceof PressurePlate) {
+					face = BlockFace.DOWN;
+				}
+
+				// Apply a force-update to the attached block
+				Block atch = sm.getBlock().getRelative(face);
+				BlockState stat = atch.getState(); // Store the state, to reapply it
+				// Trying to update with no changes does nothing, so we first set it to air, with no physics (so that the mechanism doesn't come off).
+				atch.setTypeId(0, false);
+				stat.update(true);
+			}
 		}
 
 		// set teams as started


### PR DESCRIPTION
- The hasSportBukkitApi() check is moved inside the loop, so that the loop is run even without it.
- We add a new code block inside the loop when SportBukkit is not present. The code block first determines what block to do using the Attachable interface, or just uses DOWN if it's a pressure plate.
- Once the block to update is determined, we set it to air with NO updates, then to its previous value WITH updates, which causes the desired redstone updates. This is because we don't have a way to ask for physics if nothing has changed.

Testing status:
- Levers: **Works**, although it feels laggy. That may just be my bad server.
- Buttons: Not tested
- Pressure plates: Not tested _(can you give me a map to test these with?)_
