### PR TITLE
Resolve 9 FindBugs bugs

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
@@ -2276,6 +2276,11 @@ public class AutoRefMatch implements Metadatable
 
 	/**
 	 * Parameters necessary to configure a match.
+	 * <p>
+	 * This class is serialized in through JSON.
+	 * <p>
+	 * TODO allow modification thru commands during map publication prep?
+	 *
 	 * @author authorblues
 	 */
 	public static class MatchParams

--- a/src/main/java/org/mctourney/autoreferee/AutoReferee.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoReferee.java
@@ -258,7 +258,7 @@ public class AutoReferee extends JavaPlugin
 		{
 			// if the player is expected for any of these teams
 			for (AutoRefTeam team : match.getTeams())
-				if (team.getExpectedPlayers().contains(player))
+				if (team.getExpectedPlayers().contains(player.getName()))
 					return team;
 		}
 
@@ -428,6 +428,11 @@ public class AutoReferee extends JavaPlugin
 		{
 			Player player = getServer().getPlayer(name);
 			if (player != null) world = player.getWorld();
+		}
+		if (world == null)
+		{
+			consoleWorld = null;
+			return;
 		}
 
 		this.setConsoleWorld(world);

--- a/src/main/java/org/mctourney/autoreferee/commands/ConfigurationCommands.java
+++ b/src/main/java/org/mctourney/autoreferee/commands/ConfigurationCommands.java
@@ -375,6 +375,11 @@ public class ConfigurationCommands implements CommandHandler
 			CuboidSelection csel = (CuboidSelection) sel;
 			reg = new CuboidRegion(csel.getMinimumPoint(), csel.getMaximumPoint());
 		}
+		else
+		{
+			sender.sendMessage("You must have a selection with WorldEdit already to run this method.");
+			return true;
+		}
 
 		CoreGoal core = new CoreGoal(team, reg);
 		if (options.hasOption('r'))

--- a/src/main/java/org/mctourney/autoreferee/listeners/CombatListener.java
+++ b/src/main/java/org/mctourney/autoreferee/listeners/CombatListener.java
@@ -222,6 +222,9 @@ public class CombatListener implements Listener
 			AutoRefPlayer aapl = match.getPlayer(damager);
 			AutoRefPlayer vapl = match.getPlayer(damaged);
 
+			// FIXME - define behavior for when attacker or victim is not actually in the match
+			// (and therefore aapl/vapl is null)
+
 			if (!aapl.isInsideLane())
 			{ event.setCancelled(true); return; }
 

--- a/src/main/java/org/mctourney/autoreferee/util/PlayerKit.java
+++ b/src/main/java/org/mctourney/autoreferee/util/PlayerKit.java
@@ -157,8 +157,8 @@ public class PlayerKit
 				int count = 1, damage = 0;
 
 				// cheating here a bit. Exception covers both NumberFormatException and NullPointerException
-				try { count = Integer.parseInt(gear.getAttributeValue("count")); } catch (Exception e) {  }
-				try { damage = Integer.parseInt(gear.getAttributeValue("damage")); } catch (Exception e) {  }
+				try { count = Integer.parseInt(gear.getAttributeValue("count")); } catch (Exception ignored) {  }
+				try { damage = Integer.parseInt(gear.getAttributeValue("damage")); } catch (Exception ignored) {  }
 
 				// get item stack locally so we can inspect it a bit first
 				ItemStack item = new ItemStack(type, count, (short) damage);

--- a/src/main/java/org/mctourney/autoreferee/util/QueryUtil.java
+++ b/src/main/java/org/mctourney/autoreferee/util/QueryUtil.java
@@ -72,7 +72,7 @@ public class QueryUtil
 				if (rd != null) rd.close();
 			}
 			// meh. don't bother, if something goes wrong here.
-			catch (Exception e) {  }
+			catch (Exception ignored) {  }
 		}
 	}
 

--- a/src/main/java/org/mctourney/autoreferee/util/SportBukkitUtil.java
+++ b/src/main/java/org/mctourney/autoreferee/util/SportBukkitUtil.java
@@ -62,7 +62,7 @@ public class SportBukkitUtil
 	{
 		if (mAffectsSpawning != null) try
 		{ mAffectsSpawning.invoke(player, affectsSpawning); }
-		catch (Exception e) {  }
+		catch (Throwable ignored) {  }
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class SportBukkitUtil
 	{
 		if (mCollidesWithEntities != null) try
 		{ mCollidesWithEntities.invoke(player, collidesWithEntities); }
-		catch (Exception e) {  }
+		catch (Throwable ignored) {  }
 	}
 
 	/**
@@ -93,7 +93,7 @@ public class SportBukkitUtil
 		if (mSetOverheadName != null) try
 		{ mSetOverheadName.invoke(player, overheadName.trim()
 			.replaceAll(ChatColor.RESET.toString(), "")); }
-		catch (Exception e) {  }
+		catch (Throwable ignored) {  }
 	}
 
 	/**

--- a/src/test/java/org/mctourney/autoreferee/FindPlayerTest.java
+++ b/src/test/java/org/mctourney/autoreferee/FindPlayerTest.java
@@ -17,7 +17,7 @@ public class FindPlayerTest
 		AutoRefPlayer p2 = new AutoRefPlayer("nosrepa" , null);
 		AutoRefPlayer p3 = new AutoRefPlayer("coestar" , null);
 		AutoRefPlayer p4 = new AutoRefPlayer("dewtroid", null);
-		AutoRefPlayer pX = new AutoRefPlayer("jcllpony", null);
+		// AutoRefPlayer pX = new AutoRefPlayer("jcllpony", null);
 
 		team.addPlayer(p1);
 		team.addPlayer(p2);


### PR DESCRIPTION
Resolved:
- team.getExpectedPlayers() is a collection of String, not Player
- setConsoleWorld(String) might pass null into setConsoleWorld(World) which then calls world.getUID(). This is replaced with setting explicit null (the startup value).
- (x3) SportBukkitUtil must be prepared to encounter Errors as well as Exceptions and ignore them too
- (x3) Renaming Exception parameters to 'ignored' when they are ignored
- Comment out unused player in unit test

Unresolved:
- The fields of MatchParams and TeamInfo are never written by code
- CombatListener is guaranteed to reference vapl, despite there being a nullcheck there
