### PR TITLE
Add a timeout value to QueryUtil so the plugin doesn't block the match if no response is returned.

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/util/QueryUtil.java
+++ b/src/main/java/org/mctourney/autoreferee/util/QueryUtil.java
@@ -21,6 +21,7 @@ import org.mctourney.autoreferee.AutoReferee;
 public class QueryUtil
 {
 	private static final String ENCODING = "UTF-8";
+	private static final int TIMEOUT = 5000;
 
 	public static String getUserAgent()
 	{
@@ -55,6 +56,9 @@ public class QueryUtil
 			AutoReferee instance = AutoReferee.getInstance();
 			String pluginName = instance.getDescription().getFullName();
 			conn.setRequestProperty("User-Agent", String.format("%s (%s)", pluginName, instance.getCommit()));
+
+			conn.setConnectTimeout(TIMEOUT);
+			conn.setReadTimeout(TIMEOUT);
 
 			if (method != null)
 			{


### PR DESCRIPTION
Stop the match from hanging if a HTTP connection doesn't return a result.
