### PR TITLE
Fix packet sending to send ByteArray

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
+++ b/src/main/java/org/mctourney/autoreferee/AutoRefMatch.java
@@ -1647,12 +1647,22 @@ public class AutoRefMatch implements Metadatable
 	{
 		try
 		{
+			ByteArrayOutputStream b = new ByteArrayOutputStream();
+			DataOutputStream out = new DataOutputStream(b);
+			
 			String msg = StringUtils.join(parts, SpectatorListener.DELIMITER);
+			//ASSUMING UTF
+			out.writeUTF(msg);
+			
 			ref.sendPluginMessage(AutoReferee.getInstance(), AutoReferee.REFEREE_PLUGIN_CHANNEL,
-				msg.getBytes(AutoReferee.PLUGIN_CHANNEL_ENC));
+				b.toByteArray());
 		}
-		catch (UnsupportedEncodingException e)
-		{ AutoReferee.log("Unsupported encoding: " + AutoReferee.PLUGIN_CHANNEL_ENC); }
+		catch (UnsupportedEncodingException i)
+		{ 
+			AutoReferee.log("Unsupported encoding: " + AutoReferee.PLUGIN_CHANNEL_ENC); 
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is necessary for the AR HUD Client to function. MC Forge can't handle anything else. It is also not the correct way to send packet information from the server, as shown https://www.spigotmc.org/wiki/bukkit-bungee-plugin-messaging-channel/