### PR TITLE
Added a check to handle null items in armor slots (fix for v1.10)

### DIFF
--- a/src/main/java/org/mctourney/autoreferee/util/ArmorPoints.java
+++ b/src/main/java/org/mctourney/autoreferee/util/ArmorPoints.java
@@ -53,7 +53,9 @@ public abstract class ArmorPoints
 	{
 		int armorPoints = 0;
 		for (ItemStack item : inv.getArmorContents())
+			if (item != null){
 			armorPoints += ArmorPoints.fromItemStack(item);
+			}
 		return armorPoints;
 	}
 


### PR DESCRIPTION
This null-check fixes a NPE bug in the ArmorPoints calculation code. In version 1.10, this causes a NPE due to empty item slots behaving differently. 

As a result of this bug, players were unable to join teams. 