### PR TITLE
Switch to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <bukkit.version>1.8.8-R0.1-SNAPSHOT</bukkit.version>
-    <java.target.version>1.6</java.target.version>
+    <java.target.version>1.8</java.target.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
It is the year 2020 so I see no reason not to switch. In particular all of my changes use the Java Streams API. (I'm not sure if there are other things that need to be changed to migrate to Java 8 other than the pom?)